### PR TITLE
Update slurm submission job scripts for easy use on Peloton 

### DIFF
--- a/ex1_internal/DATA/Par_file
+++ b/ex1_internal/DATA/Par_file
@@ -15,7 +15,7 @@ UTM_PROJECTION_ZONE             = 11
 SUPPRESS_UTM_PROJECTION         = .true.
 
 # number of MPI processors
-NPROC                           = 32
+NPROC                           = 16
 
 # time step parameters
 NSTEP                           = 2001

--- a/ex1_internal/DATA/meshfem3D_files/Mesh_Par_file
+++ b/ex1_internal/DATA/meshfem3D_files/Mesh_Par_file
@@ -26,7 +26,7 @@ NEX_XI                          = 48  # 648
 NEX_ETA                         = 24  # 720
 
 # number of MPI processors along xi and eta (can be different)
-NPROC_XI                        = 8
+NPROC_XI                        = 4
 NPROC_ETA                       = 4
 
 #-----------------------------------------------------------

--- a/ex1_internal/submit16_all
+++ b/ex1_internal/submit16_all
@@ -1,5 +1,6 @@
 #!/bin/bash
-#SBATCH -N 2   # node count
+#SBATCH -p high
+#SBATCH -N 1   # node count
 #SBATCH --ntasks-per-node=16
 #SBATCH -t 00:05:00
 
@@ -10,7 +11,7 @@ echo
 # script to run the mesher and the solver
 # read Par_file to get information about the run
 # compute total number of nodes needed
-NPROC=`grep NPROC DATA/Par_file | cut -d = -f 2`
+#NPROC=`grep NPROC DATA/Par_file | cut -d = -f 2`
 
 ##-DATA-
 ## run mesher
@@ -22,19 +23,19 @@ NPROC=`grep NPROC DATA/Par_file | cut -d = -f 2`
 echo starting MPI internal mesher-DAT on $NPROC processors
 sleep 2
 #cd bin
-mpiexec -n $NPROC ./bin/xmeshfem3D
+mpiexec ./bin/xmeshfem3D
 echo "done "
 echo " "
 
 # generate databases
 echo generating MPI databases-DAT on $NPROC processors
-mpiexec -n $NPROC ./bin/xgenerate_databases
+mpiexec ./bin/xgenerate_databases
 echo "done "
 echo " "
 
 # run specfem3D
 echo running solver in current directory $PWD
-mpiexec -n $NPROC ./bin/xspecfem3D
+mpiexec ./bin/xspecfem3D
 echo "finished successfully"
 echo " "
 

--- a/ex1_internal/submit16_generate
+++ b/ex1_internal/submit16_generate
@@ -1,17 +1,14 @@
 #!/bin/bash
-#SBATCH -N 2   # node count
+#SBATCH -p high
+#SBATCH -N 1   # node count
 #SBATCH --ntasks-per-node=16
-#SBATCH -t 00:05:00
+#SBATCH -t 00:01:00
 # sends mail when process begins, and
 # when it ends. Make sure you define your email
 # address.
 #SBATCH --mail-type=begin
 #SBATCH --mail-type=end
 #SBATCH --mail-user=dborisov@princeton.edu
-# load appropriate compilers/libraries
-# module load intel/13.0/64/13.0.1.117
-# module load openmpi/intel-13.0/1.6.3/64
 #cd /scratch/network/dborisov/specfem3d
 #cd /home/dborisov/packages/specfem3d
-# problems with mpiexec/mpirun so use srun
-mpiexec -n 32 ./bin/xspecfem3D
+mpiexec ./bin/xgenerate_databases

--- a/ex1_internal/submit16_mesh3d
+++ b/ex1_internal/submit16_mesh3d
@@ -1,5 +1,6 @@
 #!/bin/bash
-#SBATCH -N 2   # node count
+#SBATCH -p high
+#SBATCH -N 1   # node count
 #SBATCH --ntasks-per-node=16
 #SBATCH -t 00:01:00
 # sends mail when process begins, and
@@ -8,10 +9,7 @@
 #SBATCH --mail-type=begin
 #SBATCH --mail-type=end
 #SBATCH --mail-user=dborisov@princeton.edu
-# load appropriate compilers/libraries
-# module load intel/13.0/64/13.0.1.117
-# module load openmpi/intel-13.0/1.6.3/64
 #cd /scratch/network/dborisov/specfem3d
 #cd /home/dborisov/packages/specfem3d
 # problems with mpiexec/mpirun so use srun
-mpiexec -n 32 ./bin/xmeshfem3D
+mpiexec ./bin/xmeshfem3D

--- a/ex1_internal/submit16_specfem
+++ b/ex1_internal/submit16_specfem
@@ -1,17 +1,15 @@
 #!/bin/bash
-#SBATCH -N 2   # node count
+#SBATCH -p high
+#SBATCH -N 1   # node count
 #SBATCH --ntasks-per-node=16
-#SBATCH -t 00:01:00
+#SBATCH -t 00:05:00
 # sends mail when process begins, and
 # when it ends. Make sure you define your email
 # address.
 #SBATCH --mail-type=begin
 #SBATCH --mail-type=end
 #SBATCH --mail-user=dborisov@princeton.edu
-# load appropriate compilers/libraries
-# module load intel/13.0/64/13.0.1.117
-# module load openmpi/intel-13.0/1.6.3/64
 #cd /scratch/network/dborisov/specfem3d
 #cd /home/dborisov/packages/specfem3d
 # problems with mpiexec/mpirun so use srun
-mpiexec -n 32 ./bin/xgenerate_databases
+mpiexec ./bin/xspecfem3D

--- a/ex2_external/DATA/Par_file
+++ b/ex2_external/DATA/Par_file
@@ -15,7 +15,7 @@ UTM_PROJECTION_ZONE             = 11
 SUPPRESS_UTM_PROJECTION         = .true.
 
 # number of MPI processors
-NPROC                           = 32 
+NPROC                           = 16
 
 # time step parameters
 NSTEP                           = 2001

--- a/ex2_external/DATA/meshfem3D_files/Mesh_Par_file
+++ b/ex2_external/DATA/meshfem3D_files/Mesh_Par_file
@@ -21,8 +21,8 @@ NEX_XI                          = 48  # 648
 NEX_ETA                         = 24  # 720
 
 # number of MPI processors along xi and eta (can be different)
-NPROC_XI                        = 8
-NPROC_ETA                       = 3
+NPROC_XI                        = 4
+NPROC_ETA                       = 4
 
 # Regular/irregular mesh
 USE_REGULAR_MESH                = .true.

--- a/ex2_external/submit16_generate
+++ b/ex2_external/submit16_generate
@@ -1,5 +1,6 @@
 #!/bin/bash
-#SBATCH -N 2   # node count
+#SBATCH -p high
+#SBATCH -N 1   # node count
 #SBATCH --ntasks-per-node=16
 #SBATCH -t 00:05:00
 
@@ -7,4 +8,4 @@
 #module load intel/16.0/64/16.0.1.150
 
 # problems with mpiexec/mpirun so use srun
-mpiexec -n 32 ./bin/xspecfem3D
+mpiexec ./bin/xgenerate_databases

--- a/ex2_external/submit16_specfem
+++ b/ex2_external/submit16_specfem
@@ -1,5 +1,6 @@
 #!/bin/bash
-#SBATCH -N 2   # node count
+#SBATCH -p high
+#SBATCH -N 1   # node count
 #SBATCH --ntasks-per-node=16
 #SBATCH -t 00:05:00
 
@@ -7,4 +8,4 @@
 #module load intel/16.0/64/16.0.1.150
 
 # problems with mpiexec/mpirun so use srun
-mpiexec -n 32 ./bin/xgenerate_databases
+mpiexec ./bin/xspecfem3D


### PR DESCRIPTION
Hi Dmitry,

I have modified and added a couple parameters to the SLURM job scripts. One of those changes was to restrict each job to use at most 16 tasks per node. Peloton supports up to 32 tasks per node for full utilization however after discussing best usage of available resources, Lorraine and Bill Broadley (sys admin and creator of Peloton) decided that each group at most can use 16 processes. In total, there will be 8 nodes available. Thus, CIG will be able to support 16 groups working and submitting jobs simultaneously to Peloton. If this proves to be an issue, please let us know ASAP.

The other changes were to the NPROC factorization in DATA/Par_File and DATA/meshfem3D_files/Mesh_Par_file. I have tested the scripts and I am glad to say that everything is sound. 

A few pointers:
1. After cloning this repository, I am forced to create the following directory OUTPUT_FILES/DATABASES_MPI for each example. 
2. We currently do not support Inter compilers on Peloton. 
3. Is anaconda a required library? If so, we will take the effort to setup a module. 

Cheers,
-Harsha
